### PR TITLE
remove unused options argument

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,4 @@
-SearchSource.defineSource('packages', function(searchText, options) {
+SearchSource.defineSource('packages', function(searchText) {
   var options = {sort: {isoScore: -1}, limit: 5};
   console.log("searching for: ", searchText);
 


### PR DESCRIPTION
The options argument is not being used in the function, instead a different `options` variable is being created, no need to include it in the function signature.
